### PR TITLE
fix(register): skip logic if required element ID is missing

### DIFF
--- a/backend/public/assets/js/modal.js
+++ b/backend/public/assets/js/modal.js
@@ -348,7 +348,8 @@ window.closeEditRoleModal = function () {
 };
 
 // Mostrar u ocultar permisos al cambiar el rol
-document.getElementById("roleSelect").addEventListener("change", function () {
+if (roleSelect) {
+  roleSelect.addEventListener("change", function () {
   const selected = this.value;
   const permissionsGroup = document.getElementById('permissionsGroup');
 
@@ -362,6 +363,7 @@ document.getElementById("roleSelect").addEventListener("change", function () {
     });
   }
 });
+}
 
 //  Validar y enviar cambios
 const editRoleForm = document.getElementById('editRoleForm');


### PR DESCRIPTION
Fixed an issue in the registration flow where JavaScript execution failed if the expected HTML element ID was not present. Wrapped the logic in a conditional check to ensure compatibility across pages without the registration form.

fix/user_registration